### PR TITLE
Use git archive to build the ultimate folder destination for addon check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7.5-alpine3.10
 
 RUN apk update && \
     apk --update add libxml2-dev libxslt-dev libffi-dev gcc musl-dev libgcc openssl-dev curl && \
-    apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev
+    apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev git tar
 
 RUN python -m pip install --upgrade pip && \
     pip install kodi-addon-checker

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ The action assumes you have your addon in the root path of your repository.
 
 **Required** The name of the minimal kodi version your addon is supposed to support (Default `"leia"`).
 
+### `addon-id`
+
+**optional** The addon id of the addon being validated. This is used to extract the addon package using git achieve and respect your .gitattributes. If not provided, the addon-check will allow folder id mismatch.
+
+
+### `is-pr`
+
+**optional** If the action is being run as part of a pull request validation, normally used in automated submissions (Default `"false"`).
+
 This is equivalent to the **branch** name where your addon lives in the official kodi repository ([repo-plugins](https://github.com/xbmc/repo-plugins/branches) or [repo-scripts](https://github.com/xbmc/repo-scripts/branches)).
 
 ## Example usage

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,18 @@ inputs:
     description: 'Minimal kodi version where this addon should work (gotham, helix, isengard, jarvis, krypton, leia, matrix)'
     required: true
     default: 'leia'
+  addon-id:
+    description: 'The addon id (default empty and folder id mismatch is set to true)'
+    required: false
+    default: ''
+  is-pr:
+    description: 'If the validation is being run as part of a pull request'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.kodi-version }}
+    - ${{ inputs.addon-id }}
+    - ${{ inputs.is-pr }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,32 @@
 #!/bin/sh -l
-kodi-addon-checker --branch=$1 --allow-folder-id-mismatch .
+
+# remove dist directory if exists
+if [ -d "dist/addon-checker" ]; then
+  rm -r dist/addon-checker
+fi
+
+# create output directory
+mkdir -p dist/addon-checker
+
+# create the addon zip
+git archive --output=./dist/addon-checker/addon.tar --format=tgz HEAD
+
+# extract the addon zip to the destination where the kodi-addon-checker will run
+if [ -z "$2" ]
+then
+    ADDON_DIR="./dist/addon-checker/addon"
+    FOLDER_ID_MISMATCH="--allow-folder-id-mismatch"
+else
+    ADDON_DIR=./dist/addon-checker/$2
+    FOLDER_ID_MISMATCH=""
+fi
+mkdir -p $ADDON_DIR
+tar zxf ./dist/addon-checker/addon.tar -C $ADDON_DIR
+
+
+if [ "$3" = true ] ; then
+  kodi-addon-checker --branch=$1 $FOLDER_ID_MISMATCH --PR $ADDON_DIR
+else
+  kodi-addon-checker --branch=$1 $FOLDER_ID_MISMATCH $ADDON_DIR
+fi
+


### PR DESCRIPTION
This PR makes the action use `git archive` to create the addon package, extract it to a known location and make addon-check use that folder as the validation folder. This way we avoid the usage of `--allow-folder-id` mismatch and also respect the `export-ignore` in `.gitattributes`.

Furthermore, this PR also adds the `is-pr` input that might be usefull to run the action in the context of an automatic submission to the addon repo.