### PR TITLE
[fixes]: python 3.8 and dubious ownership issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.5-alpine3.10
+FROM python:3.8-alpine
 
 RUN apk update && \
     apk --update add libxml2-dev libxslt-dev libffi-dev gcc musl-dev libgcc openssl-dev curl && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,9 @@ fi
 # create output directory
 mkdir -p dist/addon-checker
 
+# fix detected dubious ownership in repository at '/github/workspace'
+git config --global --add safe.directory $PWD
+
 # create the addon zip
 git archive --output=./dist/addon-checker/addon.tar --format=tgz HEAD
 


### PR DESCRIPTION
This PR fix two problems:

1. Running `kodi-addon-checker` that require `Python 3.8+` (use walrus operator).
2. Detection dubious ownership in repository at '/github/workspace'. Discribed [here](https://medium.com/@janloo/github-actions-detected-dubious-ownership-in-repository-at-github-workspace-how-to-fix-b9cc127d4c04).

[Job 1](https://github.com/dudanov/kodi.plugin.audio.zophar/actions/runs/16409186878/job/46360538343)
```shell
/usr/bin/docker run --name bbe6470bf58a0b9f4945ae9be31fb1f3c5a8_f29bc3 --label 24bbe6 --workdir /github/workspace --rm -e "INPUT_KODI-VERSION" -e "INPUT_IS-PR" -e "INPUT_ADDON-ID" -e "INPUT_REWRITE-FOR-MATRIX" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/kodi.plugin.audio.zophar/kodi.plugin.audio.zophar":"/github/workspace" 24bbe6:470bf58a0b9f4945ae9be31fb1f3c5a8  "nexus" "plugin.audio.zophar" "false" "false"
Traceback (most recent call last):
  File "/usr/local/bin/kodi-addon-checker", line 5, in <module>
    from kodi_addon_checker.__main__ import main
  File "/usr/local/lib/python3.7/site-packages/kodi_addon_checker/__main__.py", line 14, in <module>
    from kodi_addon_checker import __version__, check_addon, ValidKodiVersions
  File "/usr/local/lib/python3.7/site-packages/kodi_addon_checker/check_addon.py", line 101
    if (extension := parsed_xml.find('extension')) and extension.get('point') == 'kodi.resource.language':
                  ^
SyntaxError: invalid syntax
```

[Job 2](https://github.com/dudanov/kodi.plugin.audio.zophar/actions/runs/16409908847/job/46362510965)
```shell
/usr/bin/docker run --name f1bb05e4f75c604c47dea5178f1c316b3d6c_f7294e --label 98f1bb --workdir /github/workspace --rm -e "INPUT_KODI-VERSION" -e "INPUT_IS-PR" -e "INPUT_ADDON-ID" -e "INPUT_REWRITE-FOR-MATRIX" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/kodi.plugin.audio.zophar/kodi.plugin.audio.zophar":"/github/workspace" 98f1bb:05e4f75c604c47dea5178f1c316b3d6c  "nexus" "plugin.audio.zophar" "false" "false"
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
gzip: invalid magic
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```